### PR TITLE
fix: skip invalid versions rejected by packaging 22.0

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,15 @@
+name: Update dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update dependencies
+        uses: pdm-project/update-deps-action@main

--- a/pdm.lock
+++ b/pdm.lock
@@ -135,12 +135,9 @@ summary = "Safely add untrusted strings to HTML/XML markup."
 
 [[package]]
 name = "packaging"
-version = "21.3"
-requires_python = ">=3.6"
+version = "22.0"
+requires_python = ">=3.7"
 summary = "Core utilities for Python packages"
-dependencies = [
-    "pyparsing!=3.0.5,>=2.0.2",
-]
 
 [[package]]
 name = "pluggy"
@@ -162,12 +159,6 @@ name = "pycparser"
 version = "2.21"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 summary = "C parser in Python"
-
-[[package]]
-name = "pyparsing"
-version = "3.0.9"
-requires_python = ">=3.6.8"
-summary = "pyparsing module - Classes and methods to define and execute parsing grammars"
 
 [[package]]
 name = "pytest"
@@ -270,7 +261,7 @@ requires_python = ">=3.7"
 summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
-lock_version = "4.0"
+lock_version = "4.1"
 content_hash = "sha256:9dd4d07a92b164bfb524dc2cf0c340900c9f745274de323714d5fc7c92c55e99"
 
 [metadata.files]
@@ -465,9 +456,9 @@ content_hash = "sha256:9dd4d07a92b164bfb524dc2cf0c340900c9f745274de323714d5fc7c9
     {url = "https://files.pythonhosted.org/packages/fd/f4/524d2e8f5a3727cf309c2b7df7c732038375322df1376c9e9ef3aa92fcaf/MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601"},
     {url = "https://files.pythonhosted.org/packages/ff/3a/42262a3aa6415befee33b275b31afbcef4f7f8d2f4380061b226c692ee2a/MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
 ]
-"packaging 21.3" = [
-    {url = "https://files.pythonhosted.org/packages/05/8e/8de486cbd03baba4deef4142bd643a3e7bbe954a784dc1bb17142572d127/packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
-    {url = "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+"packaging 22.0" = [
+    {url = "https://files.pythonhosted.org/packages/6b/f7/c240d7654ddd2d2f3f328d8468d4f1f876865f6b9038b146bec0a6737c65/packaging-22.0.tar.gz", hash = "sha256:2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3"},
+    {url = "https://files.pythonhosted.org/packages/8f/7b/42582927d281d7cb035609cd3a543ffac89b74f3f4ee8e1c50914bcb57eb/packaging-22.0-py3-none-any.whl", hash = "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3"},
 ]
 "pluggy 1.0.0" = [
     {url = "https://files.pythonhosted.org/packages/9e/01/f38e2ff29715251cf25532b9082a1589ab7e4f571ced434f98d0139336dc/pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -480,10 +471,6 @@ content_hash = "sha256:9dd4d07a92b164bfb524dc2cf0c340900c9f745274de323714d5fc7c9
 "pycparser 2.21" = [
     {url = "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
     {url = "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
-]
-"pyparsing 3.0.9" = [
-    {url = "https://files.pythonhosted.org/packages/6c/10/a7d0fa5baea8fe7b50f448ab742f26f52b80bfca85ac2be9d35cdd9a3246/pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
-    {url = "https://files.pythonhosted.org/packages/71/22/207523d16464c40a0310d2d4d8926daffa00ac1f5b1576170a32db749636/pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 "pytest 7.1.2" = [
     {url = "https://files.pythonhosted.org/packages/4e/1f/34657c6ac56f3c58df650ba41f8ffb2620281ead8e11bcdc7db63cf72a78/pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "pdm.pep517.api"
 name = "unearth"
 description = "A utility to fetch and download python packages"
 authors = [
-    {name = "Frost Ming", email = "mianghong@gmail.com"}
+    {name = "Frost Ming", email = "me@frostming.com"}
 ]
 license = {text = "MIT"}
 readme = "README.md"
@@ -14,7 +14,8 @@ requires-python = ">=3.7"
 dependencies = [
     "packaging>=20",
     "requests>=2.25",
-    "cached-property>=1.5.2; python_version < \"3.8\""]
+    "cached-property>=1.5.2; python_version < \"3.8\"",
+]
 dynamic = ["version"]
 
 classifiers = [
@@ -25,12 +26,13 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
 ]
 
 [project.urls]
-Repository = "https://github.com/frostming/unearth"
 Homepage = "https://github.com/frostming/unearth"
+Documentation = "https://unearth.readthedocs.io"
 Changelog = "https://github.com/frostming/unearth/releases"
 
 [project.optional-dependencies]

--- a/src/unearth/evaluator.py
+++ b/src/unearth/evaluator.py
@@ -16,7 +16,7 @@ from packaging.utils import (
     canonicalize_name,
     parse_wheel_filename,
 )
-from packaging.version import InvalidVersion
+from packaging.version import InvalidVersion, Version
 from requests import Session
 
 from unearth.link import Link
@@ -239,6 +239,12 @@ class Evaluator:
                 if version is None:
                     raise LinkMismatchError(
                         f"Missing version in the filename {egg_info}"
+                    )
+                try:
+                    Version(version)
+                except InvalidVersion:
+                    raise LinkMismatchError(
+                        f"Invalid version in the filename {egg_info}: {version}"
                     )
             self._check_hashes(link)
         except LinkMismatchError as e:


### PR DESCRIPTION
- Skip packages with invalid version
- Add auto-update dependencies workflow

This patch should fix https://github.com/pdm-project/pdm/issues/1554