### PR TITLE
Disable vcs prompt for verbosity <=0

### DIFF
--- a/src/unearth/vcs/git.py
+++ b/src/unearth/vcs/git.py
@@ -35,8 +35,10 @@ class Git(VersionControl):
     ) -> None:
         rev_display = f" (revision: {rev})" if rev else ""
         logger.info("Cloning %s%s to %s", url, rev_display, display_path(location))
+        env = None
         if self.verbosity <= 0:
             flags: tuple[str, ...] = ("--quiet",)
+            env = {"GIT_TERMINAL_PROMPT": "0"}
         elif self.verbosity == 1:
             flags = ()
         else:
@@ -47,9 +49,10 @@ class Git(VersionControl):
             # Speeds up cloning by functioning without a complete copy of repository
             self.run_command(
                 ["clone", "--filter=blob:none", *flags, url, str(location)],
+                extra_env=env,
             )
         else:
-            self.run_command(["clone", *flags, url, str(location)])
+            self.run_command(["clone", *flags, url, str(location)], extra_env=env)
 
         if rev is not None:
             self.run_command(["checkout", "-q", rev], cwd=location)


### PR DESCRIPTION
https://github.com/pdm-project/pdm/issues/1455
So with disabled git prompt pdm is now failing with this error:
```
unearth.errors.UnpackError: fatal: could not read Username for 'https://github.com': terminal prompts disabled
```
0. `GIT_TERMINAL_PROMPT` is available with git2.13+, should i check git version?
1. Do you want to catch the error and reraise with an advice here or in pdm?
2. Do you want to enable a noninteractive mode in other vcs tools?
