### PR TITLE
Migrate from deprecated pdm.pep517 to pdm.backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["pdm-pep517"]
-build-backend = "pdm.pep517.api"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
 [project]
 name = "unearth"


### PR DESCRIPTION
Trivial patch migrating from deprecated pdm.pep517 to pdm.backend.