### PR TITLE
fix: lock requests version to 2.29.0

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -208,14 +208,14 @@ summary = "UNKNOWN"
 
 [[package]]
 name = "requests"
-version = "2.31.0"
+version = "2.29.0"
 requires_python = ">=3.7"
 summary = "Python HTTP for Humans."
 dependencies = [
     "certifi>=2017.4.17",
     "charset-normalizer<4,>=2",
     "idna<4,>=2.5",
-    "urllib3<3,>=1.21.1",
+    "urllib3<1.27,>=1.21.1",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 lock_version = "4.2"
 cross_platform = true
 groups = ["default", "keyring", "test"]
-content_hash = "sha256:9dd4d07a92b164bfb524dc2cf0c340900c9f745274de323714d5fc7c92c55e99"
+content_hash = "sha256:fdd13c2aef33b7b4301e2e40984ae56bfba0fb735bf9874bad3508bb15752e5a"
 
 [metadata.files]
 "cached-property 1.5.2" = [
@@ -510,9 +510,9 @@ content_hash = "sha256:9dd4d07a92b164bfb524dc2cf0c340900c9f745274de323714d5fc7c9
     {url = "https://files.pythonhosted.org/packages/7a/7d/0dbc4c99379452a819b0fb075a0ffbb98611df6b6d59f54db67367af5bc0/pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
     {url = "https://files.pythonhosted.org/packages/9e/4b/3ab2720f1fa4b4bc924ef1932b842edf10007e4547ea8157b0b9fc78599a/pywin32_ctypes-0.2.0-py2.py3-none-any.whl", hash = "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"},
 ]
-"requests 2.31.0" = [
-    {url = "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
-    {url = "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+"requests 2.29.0" = [
+    {url = "https://files.pythonhosted.org/packages/4c/d2/70fc708727b62d55bc24e43cc85f073039023212d482553d853c44e57bdb/requests-2.29.0.tar.gz", hash = "sha256:f2e34a75f4749019bb0e3effb66683630e4ffeaf75819fb51bebef1bf5aef059"},
+    {url = "https://files.pythonhosted.org/packages/cf/e1/2aa539876d9ed0ddc95882451deb57cfd7aa8dbf0b8dbce68e045549ba56/requests-2.29.0-py3-none-any.whl", hash = "sha256:e8f3c9be120d3333921d213eef078af392fba3933ab7ed2d1cba3b56f2568c3b"},
 ]
 "requests-wsgi-adapter 0.4.1" = [
     {url = "https://files.pythonhosted.org/packages/c6/f6/8bd78fb03f1212965d7e5b566a37a3ac9a8a8ece5754203356ce7820830a/requests-wsgi-adapter-0.4.1.tar.gz", hash = "sha256:5a7709e90abf49d181f6c32aa37794537f725de0f6dd42362bc8c8c90812c878"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
     "packaging>=20",
-    "requests>=2.25",
+    "requests==2.29.0",
     "cached-property>=1.5.2; python_version < \"3.8\"",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Fixes: pdm issue [#2091](https://github.com/pdm-project/pdm/issues/2091)

Related `requests`question link: [#6443](https://github.com/psf/requests/issues/6443)