### PR TITLE
fix: include useful message if VCS command not found

### DIFF
--- a/src/unearth/vcs/base.py
+++ b/src/unearth/vcs/base.py
@@ -76,6 +76,13 @@ class VersionControl(abc.ABC):
                     logger.debug(e.stdout.rstrip())
                 return subprocess.CompletedProcess(e.args, e.returncode, e.stdout)
             raise UnpackError(e.output) from None
+        except FileNotFoundError:
+            logger.debug(f"Cannot find `{self.name}`, PATH={os.environ.get('PATH')}")
+            msg = (
+                f"Unable to find executable `{self.name}`, "
+                "make sure it's installed in PATH."
+            )
+            raise FileNotFoundError(msg) from None
         else:
             if log_output:
                 logger.debug(result.stdout.rstrip())


### PR DESCRIPTION
When the command such as `git` was not found, the error message is not clear at first glance on Windows:

`FileNotFoundError: [WinError 2] The system cannot find the file specified`

 This PR tries to make it explicit:

```[FileNotFoundError]: Unable to find executable `git`, make sure it's installed in PATH.```

https://github.com/pdm-project/pdm/issues/2209