### PR TITLE
Handle 403, 404

### DIFF
--- a/src/unearth/auth.py
+++ b/src/unearth/auth.py
@@ -345,7 +345,8 @@ class MultiDomainBasicAuth(AuthBase):
         """Response callback to warn about incorrect credentials."""
         if resp.status_code in [401, 403, 404]:
             logger.warning(
-                f"{resp.status_code} Error, Credentials not correct for %s",
+                "%s Error, Credentials not correct for %s",
+                resp.status_code,
                 resp.request.url,
             )
 

--- a/src/unearth/auth.py
+++ b/src/unearth/auth.py
@@ -85,7 +85,9 @@ class KeyringCliProvider(KeyringBaseProvider):
         """Mirror the implementation of keyring.get_password using cli"""
         cmd = [self.keyring, "get", service_name, username]
         env = dict(os.environ, PYTHONIOENCODING="utf-8")
-        res = subprocess.run(cmd, stdin=subprocess.DEVNULL, capture_output=True, env=env)
+        res = subprocess.run(
+            cmd, stdin=subprocess.DEVNULL, capture_output=True, env=env
+        )
         if res.returncode:
             return None
         return res.stdout.decode("utf-8").strip(os.linesep)
@@ -209,14 +211,18 @@ class MultiDomainBasicAuth(AuthBase):
         # If we don't have a password and keyring is available, use it.
         if allow_keyring:
             # The index url is more specific than the netloc, so try it first
-            kr_auth = get_keyring_auth(index_url, username) or get_keyring_auth(netloc, username)
+            kr_auth = get_keyring_auth(index_url, username) or get_keyring_auth(
+                netloc, username
+            )
             if kr_auth:
                 logger.debug("Found credentials in keyring for %s", netloc)
                 return kr_auth
 
         return username, password
 
-    def _get_url_and_credentials(self, original_url: str) -> tuple[str, str | None, str | None]:
+    def _get_url_and_credentials(
+        self, original_url: str
+    ) -> tuple[str, str | None, str | None]:
         """Return the credentials to use for the provided URL.
 
         If allowed, netrc and keyring may be used to obtain the


### PR DESCRIPTION
Update handling of 400 error codes such that:

* 403: Handle the same way as 401
* 404:
  * Attempt to find credentials from normal sources
  * Do not prompt if credentials are not found
* not_prompting:
  * Allow discovery of credentials when not prompting  

Addresses #69 