### PR TITLE
also fallback on "__token__" username for KeyringCliProvider

### DIFF
--- a/src/unearth/auth.py
+++ b/src/unearth/auth.py
@@ -71,11 +71,12 @@ class KeyringCliProvider(KeyringBaseProvider):
         self.keyring = cmd
 
     def get_auth_info(self, url: str, username: str | None) -> AuthInfo | None:
-        if username is not None:
-            logger.debug("Getting password from keyring CLI for %s@%s", username, url)
-            password = self._get_password(url, username)
-            if password is not None:
-                return username, password
+        if username is None:
+            username = "__token__"
+        logger.debug("Getting password from keyring CLI for %s@%s", username, url)
+        password = self._get_password(url, username)
+        if password is not None:
+            return username, password
         return None
 
     def save_auth_info(self, url: str, username: str, password: str) -> None:


### PR DESCRIPTION
At my company we hit a strange case were a given simple unearth request would either fail or succeed in a same environment depending on wether the `keyring` package was installed or not.
Then we found out https://github.com/frostming/unearth/issues/18, and we think it would make more sense than the backport also exists for when the keyring package is not installed.

Feel free to change the code if the current form does not please you.
