### PR TITLE
fix: revert the handling of 403 and 404

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", 3.12]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up PDM
         uses: pdm-project/setup-pdm@v3
         with:

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,13 +5,13 @@ import nox
 os.environ.update(PDM_IGNORE_SAVED_PYTHON="1", PDM_USE_VENV="1")
 
 
-@nox.session(python=("3.7", "3.8", "3.9", "3.10", "3.11"))
+@nox.session(python=("3.7", "3.8", "3.9", "3.10", "3.11", "3.12"))
 def test(session):
     session.run("pdm", "install", "-Gtest", external=True)
     session.run("pytest", "tests/")
 
 
-@nox.session(python="3.9")
+@nox.session(python="3.11")
 def docs(session):
     session.install("-r", "docs/requirements.txt")
 
@@ -19,7 +19,7 @@ def docs(session):
     session.run("sphinx-build", "-n", "-W", "-b", "html", "docs/", "build/docs")
 
 
-@nox.session(name="docs-live", python="3.10")
+@nox.session(name="docs-live", python="3.11")
 def docs_live(session):
     session.install("-r", "docs/requirements.txt")
     session.install("-e", ".")

--- a/src/unearth/auth.py
+++ b/src/unearth/auth.py
@@ -235,7 +235,9 @@ class MultiDomainBasicAuth(AuthBase):
         _, url = split_auth_from_url(original_url)
         netloc = urlparse(url).netloc
         # Try to get credentials from original url
-        username, password = self._get_new_credentials(original_url)
+        username, password = self._get_new_credentials(
+            original_url, allow_netrc=True, allow_keyring=False
+        )
 
         # If credentials not found, use any stored credentials for this netloc.
         # Do this if either the username or the password is missing.

--- a/src/unearth/auth.py
+++ b/src/unearth/auth.py
@@ -262,7 +262,7 @@ class MultiDomainBasicAuth(AuthBase):
         if username is not None and password is not None:
             req = HTTPBasicAuth(username, password)(req)
 
-        # Attach a hook to handle 400 responses
+        # Attach a hook to handle 401 responses
         req.register_hook("response", self.handle_401)
 
         return req
@@ -303,7 +303,6 @@ class MultiDomainBasicAuth(AuthBase):
         save = False
         if not username and not password:
             # We are not able to prompt the user so simply return the response
-            # Also, do not prompt on 404
             if not self.prompting:
                 return resp
 


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

This PR reverts some changes made by #70 but uses a different way, so that:

Before sending request to the index, the credentials in netrc will be read to authenticate the request.  And **only** when the request fails with 401 error, the keyring will be queried and then prompt in the console.

This means if your index returns 403 or even 404 on unauthorized requests, you must rely on the credentials provided via netrc. Otherwise the error response will be returned without any atttempt to load other credentials.

This behavior is also the same as pip.