### PR TITLE
Update hg.py to use the commit hash instead of the local identity

### DIFF
--- a/src/unearth/vcs/hg.py
+++ b/src/unearth/vcs/hg.py
@@ -46,7 +46,7 @@ class Mercurial(VersionControl):
 
     def get_revision(self, location: Path) -> str:
         current_revision = self.run_command(
-            ["parents", "--template={rev}"],
+            ["parents", "--template={node}"],
             log_output=False,
             stdout_only=True,
             cwd=location,


### PR DESCRIPTION
Seems to fix https://github.com/pdm-project/pdm/issues/2536

The result of `hg parent -T "{rev}"` is a local revision number.