### PR TITLE
fix: don't show warning message when no netrc exists

### DIFF
--- a/src/unearth/utils.py
+++ b/src/unearth/utils.py
@@ -299,6 +299,8 @@ def get_netrc_auth(url: str) -> tuple[str, str] | None:
 
     try:
         authenticator = netrc(os.getenv("NETRC"))
+    except FileNotFoundError:
+        return None
     except (NetrcParseError, OSError) as e:
         logger.warning("Couldn't parse netrc because of %s: %s", type(e).__name__, e)
         return None


### PR DESCRIPTION
closes frostming/unearth#139