### PR TITLE
really drop python<=3.7 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,10 +90,10 @@ extend-select = [
 extend-ignore = ["B018", "B019"]
 exclude = ["tests/fixtures"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["unearth"]
 
 [tool.pytest.ini_options]

--- a/src/unearth/fetchers/legacy.py
+++ b/src/unearth/fetchers/legacy.py
@@ -57,7 +57,7 @@ class LocalFSAdapter(adapters.BaseAdapter):
             # to return a better error message:
             resp.status_code = 404
             resp.reason = type(exc).__name__
-            resp.raw = io.BytesIO(f"{resp.reason}: {exc}".encode("utf8"))
+            resp.raw = io.BytesIO(f"{resp.reason}: {exc}".encode())
         else:
             modified = email.utils.formatdate(stats.st_mtime, usegmt=True)
             content_type = mimetypes.guess_type(path)[0] or "text/plain"

--- a/src/unearth/utils.py
+++ b/src/unearth/utils.py
@@ -31,7 +31,7 @@ def add_ssh_scheme_to_git_uri(uri: str) -> str:
         parsed = parse.urlparse(uri)
         if ":" in parsed.netloc:
             netloc, _, path_start = parsed.netloc.rpartition(":")
-            path = "/{0}{1}".format(path_start, parsed.path)
+            path = f"/{path_start}{parsed.path}"
             uri = parse.urlunparse(parsed._replace(netloc=netloc, path=path))
     return uri
 
@@ -227,7 +227,7 @@ class LazySequence(Sequence[T]):
 _legacy_specifier_re = re.compile(r"(==|!=|<=|>=|<|>)(\s*)([^,;\s)]*)")
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def fix_legacy_specifier(specifier: str) -> str:
     """Since packaging 22.0, legacy specifiers like '>=4.*' are no longer
     supported. We try to normalize them to the new format.

--- a/src/unearth/vcs/base.py
+++ b/src/unearth/vcs/base.py
@@ -235,7 +235,7 @@ _V = TypeVar("_V", bound=Type[VersionControl])
 
 class VcsSupport:
     def __init__(self) -> None:
-        self._registry: dict[str, Type[VersionControl]] = {}
+        self._registry: dict[str, type[VersionControl]] = {}
 
     def register(self, vcs: _V) -> _V:
         self._registry[vcs.name] = vcs


### PR DESCRIPTION
Filter all code over `pyupgracde --py38-plus`.