### PR TITLE
chore: add tests for utils.get_netrc_auth logging

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
+import logging
 from unittest import mock
 
-from unearth.utils import LazySequence
+from unearth.utils import LazySequence, get_netrc_auth
 
 
 def test_lazy_sequence():
@@ -23,3 +24,29 @@ def test_lazy_sequence():
     assert len(seq) == 5
     assert list(seq) == [0, 1, 2, 3, 4]
     assert func.call_count == 5
+
+
+def test_get_netrc_auth_when_unparsable(caplog, monkeypatch, tmp_path):
+    url = "https://test.invalid/blah"
+    netrc_path = tmp_path / "netrc"
+    netrc_path.write_text("invalid netrc entry", encoding="utf8")
+    monkeypatch.setenv("NETRC", str(netrc_path))
+    caplog.set_level(logging.WARNING)
+
+    get_netrc_auth(url)
+
+    msgs = [i.msg for i in caplog.records]
+    msg = "Couldn't parse netrc because of %s: %s"
+    assert msg in msgs
+
+
+def test_get_netrc_auth_when_netrc_missing(caplog, monkeypatch, tmp_path):
+    url = "https://test.invalid/blah"
+    monkeypatch.setenv("NETRC", str(tmp_path / "bogus"))
+    caplog.set_level(logging.WARNING)
+
+    get_netrc_auth(url)
+
+    msgs = [i.msg for i in caplog.records]
+    msg = "Couldn't parse netrc because of %s: %s"
+    assert msg not in msgs


### PR DESCRIPTION
Thank you for merging PR #139. I realized from the PR comments that it might have been better to demonstrate the change with some tests. I'm now submitting some unit tests. For inclusion.  The `test_get_netrc_auth_when_netrc_missing` in particular would have failed before PR #139.