### PR TITLE
fix: support packaging 26.0 changes

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -708,13 +708,13 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "25.0"
+version = "26.0"
 requires_python = ">=3.8"
 summary = "Core utilities for Python packages"
 groups = ["default", "doc", "test"]
 files = [
-    {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
-    {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
+    {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
+    {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
 ]
 
 [[package]]

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -251,9 +251,9 @@ def test_evaluate_compatibility_tags(link, expected, ignore_compatibility):
         ("8.1.3", ">=8.0", None, True),
         ("7.1", ">=8.0", None, False),
         ("8.0.0a0", ">=8.0.0dev0", None, True),
-        ("8.0.0dev0", ">=7", None, False),
+        ("8.0.0dev0", ">=7", False, False),
         ("8.0.0dev0", ">=7", True, True),
-        ("8.0.0a0", "", None, False),
+        ("8.0.0a0", "", False, False),
         ("8.0.0a0", ">=8.0.0dev0", False, False),
     ],
 )


### PR DESCRIPTION
packaging 26.0 changed how Specifier.contains() behaves with prereleases=None[0], so call it with False explicitly in the two tests that fail without it.

0: https://github.com/pypa/packaging/issues/895